### PR TITLE
feat: enhance Result component with editable FEN and PGN inputs

### DIFF
--- a/fengine-frontend/src/pages/Result.jsx
+++ b/fengine-frontend/src/pages/Result.jsx
@@ -113,7 +113,7 @@ export default function Result() {
                 console.error("Invalid FEN string:", error);
                 setNotationError(`Invalid FEN: ${error.message}`);
             }
-        }, 500); // 500ms debounce
+        }, FEN_DEBOUNCE_DELAY_MS); // debounce
 
         // Clean up the timer
         return () => clearTimeout(debounceTimer);

--- a/fengine-frontend/src/pages/Result.jsx
+++ b/fengine-frontend/src/pages/Result.jsx
@@ -10,10 +10,12 @@ axios.defaults.baseURL = 'http://localhost:8000'; // or whatever port your FastA
 export default function Result() {
     const { state } = useLocation();
     const navigate = useNavigate();
-    const [result, setResult] = useState({ fen: '', pgn: '' });
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
     const [game, setGame] = useState(null);
+    const [editableFen, setEditableFen] = useState('');
+    const [editablePgn, setEditablePgn] = useState('');
+    const [notationError, setNotationError] = useState('');
 
     useEffect(() => {
         if (!state?.file) {
@@ -33,7 +35,8 @@ export default function Result() {
 
         axios.post('/api/ocr', formData)
             .then(res => {
-                setResult(res.data);
+                setEditableFen(res.data.fen);
+                setEditablePgn(res.data.pgn);
                 setLoading(false);
             })
             .catch(err => {
@@ -57,25 +60,114 @@ export default function Result() {
             });
     }, [state, navigate]);
 
+    // Validate and apply FEN when it changes
     useEffect(() => {
-        // Initialize chess.js with the FEN string
-        if (result.fen) {
+        if (!editableFen) return;
+
+        // We'll use a delayed execution to avoid constantly updating while typing
+        const debounceTimer = setTimeout(() => {
             try {
-                const newGame = new Chess(result.fen);
-                setGame(newGame);
+                // Check if the FEN has all six required fields
+                const fenParts = editableFen.trim().split(' ');
+                if (fenParts.length < 6) {
+                    // Try to fix the FEN by adding missing parts with defaults
+                    let fixedFen = editableFen;
+
+                    // Standard field order: position active castling en-passant halfmove fullmove
+                    if (fenParts.length === 1) {
+                        // Just the position - add all other fields
+                        fixedFen += " w KQkq - 0 1";
+                    } else if (fenParts.length === 2) {
+                        // Position and active color - add remaining fields
+                        fixedFen += " KQkq - 0 1";
+                    } else if (fenParts.length === 3) {
+                        // Position, active color, and castling - add remaining fields
+                        fixedFen += " - 0 1";
+                    } else if (fenParts.length === 4) {
+                        // Position, active color, castling, and en passant - add remaining fields
+                        fixedFen += " 0 1";
+                    } else if (fenParts.length === 5) {
+                        // Position, active color, castling, en passant, and halfmove - add fullmove
+                        fixedFen += " 1";
+                    }
+
+                    // Create a new Chess instance with the fixed FEN
+                    const newGame = new Chess();
+                    newGame.load(fixedFen);
+                    setGame(newGame);
+
+                    // Update the editable FEN with the complete version
+                    setEditableFen(newGame.fen());
+                    setNotationError('');
+                } else {
+                    // FEN seems complete, try to load it directly
+                    const newGame = new Chess();
+                    newGame.load(editableFen);
+                    setGame(newGame);
+                    setNotationError('');
+
+                    // Also update the PGN
+                    setEditablePgn(generateBasicPgn(editableFen));
+                }
             } catch (error) {
                 console.error("Invalid FEN string:", error);
-                // Fall back to starting position if FEN is invalid
-                try {
-                    const defaultGame = new Chess();
-                    setGame(defaultGame);
-                    console.log("Using default starting position instead");
-                } catch (err) {
-                    console.error("Failed to create default chess instance:", err);
-                }
+                setNotationError(`Invalid FEN: ${error.message}`);
             }
+        }, 500); // 500ms debounce
+
+        // Clean up the timer
+        return () => clearTimeout(debounceTimer);
+    }, [editableFen]);
+
+    // Generate a basic PGN from a FEN string
+    const generateBasicPgn = (fen) => {
+        try {
+            const newGame = new Chess();
+            newGame.load(fen);
+
+            // Extract position info from FEN
+            const [_position, _activeColor, _castling, _enPassant, _halfMove, _fullMove] = fen.split(' ');
+
+            // Build a simple PGN
+            return [
+                '[Event "Chess Position"]',
+                '[Site "FENgine"]',
+                '[Date "????.??.??"]',
+                '[Round "?"]',
+                '[White "?"]',
+                '[Black "?"]',
+                '[Result "*"]',
+                `[FEN "${fen}"]`,
+                '[SetUp "1"]',
+                '',
+                '*'
+            ].join('\n');
+        } catch (error) {
+            console.error("Error generating PGN:", error);
+            return "";
         }
-    }, [result.fen]);
+    };
+
+    const handleFenChange = (e) => {
+        setEditableFen(e.target.value);
+    };
+
+    const handlePgnChange = (e) => {
+        setEditablePgn(e.target.value);
+    };
+
+    const applyPgn = () => {
+        try {
+            const newGame = new Chess();
+            newGame.loadPgn(editablePgn);
+            setGame(newGame);
+            setEditableFen(newGame.fen());
+            setNotationError('');
+        } catch (error) {
+            console.error("Invalid PGN:", error);
+            setNotationError(`Invalid PGN: ${error.message}`);
+        }
+    };
 
     if (loading) return <div className="p-4">Processing image...</div>;
     if (error) return <div className="p-4 text-red-600">{error}</div>;
@@ -103,11 +195,43 @@ export default function Result() {
                 </div>
             </div>
 
+            {notationError && (
+                <div className="p-2 mb-4 bg-red-100 text-red-700 rounded">
+                    {notationError}
+                </div>
+            )}
+
             <h2 className="text-xl font-semibold mb-2">FEN</h2>
-            <code className="block p-2 bg-gray-200 mb-4 overflow-x-auto">{result.fen}</code>
+            <div className="mb-4">
+                <textarea
+                    className="w-full p-2 bg-gray-200 font-mono text-sm overflow-x-auto"
+                    value={editableFen}
+                    onChange={handleFenChange}
+                    rows={2}
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                    Edit the FEN string above - the board will update automatically.
+                </p>
+            </div>
 
             <h2 className="text-xl font-semibold mb-2">PGN</h2>
-            <pre className="p-2 bg-gray-100 overflow-x-auto">{result.pgn}</pre>
+            <div className="mb-4">
+                <textarea
+                    className="w-full p-2 bg-gray-100 font-mono text-sm overflow-x-auto"
+                    value={editablePgn}
+                    onChange={handlePgnChange}
+                    rows={6}
+                />
+                <button
+                    onClick={applyPgn}
+                    className="mt-2 px-4 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+                >
+                    Apply PGN
+                </button>
+                <p className="text-xs text-gray-500 mt-1">
+                    Edit the PGN notation above and click "Apply PGN" to update the board.
+                </p>
+            </div>
         </div>
     );
 }

--- a/fengine-frontend/src/pages/Result.jsx
+++ b/fengine-frontend/src/pages/Result.jsx
@@ -126,7 +126,6 @@ export default function Result() {
             newGame.load(fen);
 
             // Extract position info from FEN
-            const [_position, _activeColor, _castling, _enPassant, _halfMove, _fullMove] = fen.split(' ');
 
             // Build a simple PGN
             return [

--- a/fengine-frontend/src/pages/Result.jsx
+++ b/fengine-frontend/src/pages/Result.jsx
@@ -97,7 +97,10 @@ export default function Result() {
                     setGame(newGame);
 
                     // Update the editable FEN with the complete version
-                    setEditableFen(newGame.fen());
+                    // Update the editable FEN with the complete version, only if it differs from the current value
+                    if (newGame.fen() !== editableFen) {
+                        setEditableFen(newGame.fen());
+                    }
                     setNotationError('');
                 } else {
                     // FEN seems complete, try to load it directly


### PR DESCRIPTION
This pull request enhances the `Result` page in the frontend by allowing users to directly edit and validate FEN and PGN chess notations, with immediate feedback and error handling. The board and notations now update live as the user types, and user input is validated and auto-corrected where possible. The UI has been updated to support these new features.

**User-editable FEN and PGN with live validation and feedback:**

* Added `editableFen`, `editablePgn`, and `notationError` state variables, replacing the previous `result` state, to support user editing and error display.
* Implemented logic to validate and auto-complete FEN strings as the user types, including auto-filling missing FEN fields and updating the board and PGN accordingly. Errors are displayed if the FEN is invalid.
* Added a function to generate a basic PGN from a FEN string, ensuring the PGN stays in sync with FEN edits.
* Enabled editing of the PGN with a textarea and an "Apply PGN" button, which updates the board and FEN if the PGN is valid, or shows an error if not.

**UI updates:**

* Replaced static FEN/PGN display with editable textareas, added error message display, and improved user instructions for editing and applying changes.

**Integration with backend response:**

* Updated the logic to set the editable FEN and PGN fields based on the backend OCR response, ensuring the UI is initialized with the latest data.