### PR TITLE
fix: handle None return in detect_and_warp and resize image if no contour found

### DIFF
--- a/fengine-backend/processing.py
+++ b/fengine-backend/processing.py
@@ -72,10 +72,23 @@ def classify_cells(warped_board):
 
             # Preprocess cell for the model
             cell = cv2.resize(cell, (64, 64))  # Resize to model input size
-            cell = cell / 255.0  # Normalize
+
+            # Convert to grayscale (this is the key fix)
+            cell_gray = cv2.cvtColor(cell, cv2.COLOR_BGR2GRAY)
+
+            # Normalize
+            cell_gray = cell_gray / 255.0
+
+            # Reshape to match model's expected input shape (add channel dimension)
+            cell_input = np.expand_dims(cell_gray, axis=-1)  # Shape becomes (64, 64, 1)
+
+            # Add batch dimension
+            cell_input = np.expand_dims(
+                cell_input, axis=0
+            )  # Shape becomes (1, 64, 64, 1)
 
             # Classify the cell
-            prediction = model.predict(np.expand_dims(cell, axis=0))
+            prediction = model.predict(cell_input)
             piece_label = np.argmax(prediction)
 
             # Store the label
@@ -242,3 +255,19 @@ def generate_pgn_from_fen(fen):
 [SetUp "1"]
 
 *"""
+
+
+def check_model_input_shape():
+    """
+    Print the expected input shape for the model to help with debugging
+    """
+    # Get the input shape from the model
+    input_shape = model.layers[0].input_shape
+    print(f"Model expects input shape: {input_shape}")
+
+    # Call this function when your app starts up
+    return input_shape
+
+
+# Add this line near the top of the file after model loading
+input_shape = check_model_input_shape()


### PR DESCRIPTION
This pull request improves the robustness and accuracy of the chessboard image processing pipeline in the backend. The most important changes include better error handling, improved preprocessing for model input, and fallback logic for cases where the chessboard cannot be detected.

**Image Processing Robustness:**

* Added a try/except block in `process_image` to catch and log errors during image processing, returning a clear HTTP 500 error if something goes wrong.
* Ensured that if `detect_and_warp` fails to find a valid chessboard contour, the original image is resized to 800x800 and used as a fallback, preventing downstream errors. [[1]](diffhunk://#diff-d5498f705c4585876c995d6a759511c07f01dd8ff61da47739df2078ac303d70L136-R152) [[2]](diffhunk://#diff-bb0f3f7fb9b53a87c8e30385a51d678326c9373b666c633e4a24494d3df36dd5R38-R48)

**Model Input Preprocessing:**

* Updated `classify_cells` to convert each cell to grayscale, normalize, and reshape to match the model's expected input shape, improving classification accuracy and preventing shape mismatch errors.
* Added a utility function `check_model_input_shape` to print and verify the model's expected input shape at startup for easier debugging.