### PR TITLE
feat: add batch processing for classify_cells and improve prediction efficiency

### DIFF
--- a/fengine-backend/main.py
+++ b/fengine-backend/main.py
@@ -4,6 +4,7 @@ from processing import classify_cells, generate_notation
 import numpy as np
 import cv2
 import traceback
+import time
 
 app = FastAPI()
 
@@ -36,7 +37,9 @@ async def process_image(file: UploadFile = File(...), corrections: str = None):
 
         # Process the image
         try:
+            start_time = time.time()
             warped = detect_and_warp(img)
+            warp_time = time.time() - start_time
 
             # Ensure warped is not None
             if warped is None:
@@ -46,7 +49,12 @@ async def process_image(file: UploadFile = File(...), corrections: str = None):
             # Save the warped image for debugging (optional)
             # cv2.imwrite("debug_warped.jpg", warped)
 
+            start_time = time.time()
             board_labels = classify_cells(warped)
+            classify_time = time.time() - start_time
+
+            print(f"Time to warp: {warp_time:.2f} seconds")
+            print(f"Time to classify: {classify_time:.2f} seconds")
 
             # Debug print the board
             print("Detected board before corrections:")


### PR DESCRIPTION
This pull request introduces performance profiling for image processing and adds a new batch classification method to improve cell classification efficiency. The changes enhance debugging and optimize the classification workflow.

### Performance profiling and debugging

* Added timing code to measure and print the duration of the image warping and cell classification steps in `process_image`, aiding performance analysis. [[1]](diffhunk://#diff-bb0f3f7fb9b53a87c8e30385a51d678326c9373b666c633e4a24494d3df36dd5R40-R42) [[2]](diffhunk://#diff-bb0f3f7fb9b53a87c8e30385a51d678326c9373b666c633e4a24494d3df36dd5R52-R57)
* Imported the `time` module in `main.py` to support timing measurements.

### Cell classification improvements

* Added a new `classify_cells_batch` function in `processing.py` for batch processing of chessboard cells, reducing the number of prediction calls and improving efficiency.
* Updated the `model.predict` call in `classify_cells` to use `verbose=0`, suppressing unnecessary output during predictions.